### PR TITLE
[feat] 유저 Owner 권한 추가, 예약 상태 enum 추가, jacoco 제외 클래스 추가

### DIFF
--- a/.github/workflows/pr-action.yml
+++ b/.github/workflows/pr-action.yml
@@ -39,7 +39,7 @@ jobs:
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-       run: ./gradlew build test sonar --info --stacktrace
+       run: ./gradlew build sonar --info
 
      - name: pull-request-test-success-slack-notice
        uses: 8398a7/action-slack@v3

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ sonar {
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
         property 'sonar.test.inclusions', '**/*Test.java'
-//        property 'sonar.coveragePlugin', 'jacoco'
-//        property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
+        property 'sonar.coveragePlugin', 'jacoco'
+        property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,12 +75,13 @@ def jacocoExcludePatterns = [
         "**/*Interceptor*",
         "**/*Filter*",
         "**/*Resolver*",
-        "**/com/projectw/domain/**/entity",
+        "**/entity/**",
         "**/dto/**",
         "**/test/**",
         "**/resources/**",
-        "**/security",
-        "**/common",
+        "**/security/**",
+        "**/common/**",
+        "**/controller/**"
 ]
 
 sonar {
@@ -92,7 +93,7 @@ sonar {
         property "sonar.tests", "src/test/java"
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+        property 'sonar.test.exclusions', "**/*Application*, **/*Config*, **/*Aop*, **/*Exception*, **/*Request*, **/*Response*, **/*Interceptor*, **/*Filter*, **/*Resolver*, **/entity/**, **/dto/**, **/test/**, **/resources/**, **/security/**, **/common/**, **/controller/**"
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.coveragePlugin', 'jacoco'
         property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ sonar {
         property "sonar.organization", "final17"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.sources", "src/main/java"
+        property 'sonar.exclusions', jacocoExcludePatterns.join(",") // 제외
         property "sonar.tests", "src/test/java"
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,8 @@ def jacocoExcludePatterns = [
         "**/dto/**",
         "**/test/**",
         "**/resources/**",
-        "**/security/**",
-        "**/common/**"
+        "**/security",
+        "**/common",
 ]
 
 sonar {
@@ -94,8 +94,8 @@ sonar {
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
         property 'sonar.test.inclusions', '**/*Test.java'
-        property 'sonar.coveragePlugin', 'jacoco'
-        property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
+//        property 'sonar.coveragePlugin', 'jacoco'
+//        property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ sonar {
         property "sonar.tests", "src/test/java"
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.test.exclusions', "**/*Application*, **/*Config*, **/*Aop*, **/*Exception*, **/*Request*, **/*Response*, **/*Interceptor*, **/*Filter*, **/*Resolver*, **/entity/**, **/dto/**, **/test/**, **/resources/**, **/security/**, **/common/**, **/controller/**"
+        property 'sonar.test.exclusions', jacocoExcludePatterns.join(",")
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.coveragePlugin', 'jacoco'
         property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -77,11 +77,11 @@ def jacocoExcludePatterns = [
         "**/*Resolver*",
         "**/test/**",
         "**/resources/**",
-        "**/entity/**/*",
-        "**/dto/**/*",
-        "**/security/**/",
-        "**/common/**/*",
-        "**/controller/**/*"
+        "**/entity/**",
+        "**/dto/**",
+        "**/security/**",
+        "**/common/**",
+        "**/controller/**"
 ]
 
 sonar {

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    // redison
+    // redisson
     implementation group: 'org.redisson', name: 'redisson', version: '3.37.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -60,9 +60,9 @@ dependencies {
 
 
 /*----------- sonar, jacoco -----------*/
-def QDomains = []
-for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
-    QDomains.add(qPattern + '*')
+def Qdomains = []
+for (qPattern in '**/QA'..'**/QZ') {
+    Qdomains.add(qPattern + '*')
 }
 def jacocoExcludePatterns = [
         // 측정 안하고 싶은 패턴
@@ -72,13 +72,15 @@ def jacocoExcludePatterns = [
         "**/*Exception*",
         "**/*Request*",
         "**/*Response*",
-        "**/*Dto*",
         "**/*Interceptor*",
         "**/*Filter*",
         "**/*Resolver*",
-        "**/*Entity*",
+        "**/com/projectw/domain/**/entity",
+        "**/dto/**",
         "**/test/**",
-        "**/resources/**"
+        "**/resources/**",
+        "**/security/**",
+        "**/common/**"
 ]
 
 sonar {
@@ -117,7 +119,7 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: jacocoExcludePatterns + QDomains) // Querydsl 관련 제거
+                    fileTree(dir: it, excludes: jacocoExcludePatterns + Qdomains) // Querydsl 관련 제거
                 })
         )
     }

--- a/build.gradle
+++ b/build.gradle
@@ -75,13 +75,13 @@ def jacocoExcludePatterns = [
         "**/*Interceptor*",
         "**/*Filter*",
         "**/*Resolver*",
-        "**/entity/**",
-        "**/dto/**",
         "**/test/**",
         "**/resources/**",
-        "**/security/**",
-        "**/common/**",
-        "**/controller/**"
+        "**/entity/**/*",
+        "**/dto/**/*",
+        "**/security/**/",
+        "**/common/**/*",
+        "**/controller/**/*"
 ]
 
 sonar {

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/projectw/common/enums/ReservationStatus.java
+++ b/src/main/java/com/projectw/common/enums/ReservationStatus.java
@@ -1,0 +1,5 @@
+package com.projectw.common.enums;
+
+public enum ReservationStatus {
+    WAITING, REFUSED, COMPLETED
+}

--- a/src/main/java/com/projectw/common/enums/ResponseCode.java
+++ b/src/main/java/com/projectw/common/enums/ResponseCode.java
@@ -16,6 +16,8 @@ public enum ResponseCode {
 
     // 사용자
     NOT_FOUND_USER("해당 사용자는 존재하지 않습니다."),
+    NOT_FOUND_STORE("해당 가게는 존재하지 않습니다."),
+    NOT_FOUND_RESERVATION("해당 예약은 존재하지 않습니다."),
     INVALID_USER_AUTHORITY("해당 사용자 권한은 유효하지 않습니다."),
     DUPLICATE_EMAIL("이미 존재하는 이메일입니다."),
     WRONG_USERNAME_OR_PASSWORD("아이디 혹은 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/projectw/common/enums/UserRole.java
+++ b/src/main/java/com/projectw/common/enums/UserRole.java
@@ -1,15 +1,17 @@
 package com.projectw.common.enums;
 
-import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserRole {
 
     ROLE_USER(Authority.USER),
-    ROLE_ADMIN(Authority.ADMIN);
+    ROLE_ADMIN(Authority.ADMIN),
+    ROLE_OWNER(Authority.OWNER);
 
     private final String userRole;
 
@@ -23,5 +25,6 @@ public enum UserRole {
     public static class Authority {
         public static final String USER = "ROLE_USER";
         public static final String ADMIN = "ROLE_ADMIN";
+        public static final String OWNER = "ROLE_OWNER";
     }
 }

--- a/src/main/java/com/projectw/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/com/projectw/domain/auth/dto/AuthResponse.java
@@ -4,7 +4,7 @@ import com.projectw.domain.auth.dto.AuthResponse.DuplicateCheck;
 import com.projectw.domain.auth.dto.AuthResponse.Reissue;
 import com.projectw.domain.auth.dto.AuthResponse.Login;
 import com.projectw.domain.auth.dto.AuthResponse.Signup;
-import com.projectw.domain.user.entitiy.User;
+import com.projectw.domain.user.entity.User;
 
 public sealed interface AuthResponse permits Signup, Login, Reissue, DuplicateCheck {
 

--- a/src/main/java/com/projectw/domain/auth/service/AuthService.java
+++ b/src/main/java/com/projectw/domain/auth/service/AuthService.java
@@ -13,7 +13,7 @@ import com.projectw.domain.auth.dto.AuthResponse;
 import com.projectw.domain.auth.dto.AuthResponse.DuplicateCheck;
 import com.projectw.domain.auth.dto.AuthResponse.Reissue;
 import com.projectw.domain.auth.dto.AuthResponse.Signup;
-import com.projectw.domain.user.entitiy.User;
+import com.projectw.domain.user.entity.User;
 import com.projectw.domain.user.repository.UserRepository;
 import com.projectw.security.AuthUser;
 import com.projectw.security.JwtUtil;

--- a/src/main/java/com/projectw/domain/reservation/controller/ReservationOwnerController.java
+++ b/src/main/java/com/projectw/domain/reservation/controller/ReservationOwnerController.java
@@ -1,0 +1,31 @@
+package com.projectw.domain.reservation.controller;
+
+import com.projectw.common.dto.SuccessResponse;
+import com.projectw.common.enums.UserRole;
+import com.projectw.domain.reservation.dto.ReserveRequest;
+import com.projectw.domain.reservation.dto.ReserveResponse;
+import com.projectw.domain.reservation.service.ReservationService;
+import com.projectw.security.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ReservationOwnerController {
+
+    private final ReservationService reservationService;
+
+    @Secured({ UserRole.Authority.OWNER })
+    @PatchMapping("/api/stores/{storeId}/reservations/{reservationId}/status")
+    public ResponseEntity<SuccessResponse<ReserveResponse.Info>> changeStatus(
+            @PathVariable long storeId,
+            @PathVariable long reservationId,
+            @AuthenticationPrincipal AuthUser user,
+            @RequestBody ReserveRequest.UpdateStatus request) {
+
+        return ResponseEntity.ok(reservationService.reservationStatusChange(user,storeId, reservationId, request));
+    }
+}

--- a/src/main/java/com/projectw/domain/reservation/dto/ReserveRequest.java
+++ b/src/main/java/com/projectw/domain/reservation/dto/ReserveRequest.java
@@ -1,0 +1,21 @@
+package com.projectw.domain.reservation.dto;
+
+
+import com.projectw.common.enums.ReservationStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public sealed interface ReserveRequest permits ReserveRequest.Create, ReserveRequest.UpdateStatus {
+
+    record Create(
+            Long storeId,
+            Long reservationNumber,
+            Integer numberOfGuests,
+            LocalDate reservationDate,
+            LocalTime reservationTime
+    ) implements ReserveRequest {}
+
+    record UpdateStatus(ReservationStatus status) implements ReserveRequest {
+    }
+}

--- a/src/main/java/com/projectw/domain/reservation/dto/ReserveResponse.java
+++ b/src/main/java/com/projectw/domain/reservation/dto/ReserveResponse.java
@@ -1,0 +1,35 @@
+package com.projectw.domain.reservation.dto;
+
+import com.projectw.common.enums.ReservationStatus;
+import com.projectw.domain.reservation.dto.ReserveResponse.Info;
+import com.projectw.domain.reservation.entity.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public sealed interface ReserveResponse permits Info {
+
+    record Info (
+            Long reserveId,
+            Long userId,
+            Long storeId,
+            Long reservationNumber,
+            Integer numberOfGuests,
+            LocalDate reservationDate,
+            LocalTime reservationTime,
+            ReservationStatus status
+    ) implements ReserveResponse {
+        public Info(Reservation reservation) {
+            this(
+                    reservation.getId(),
+                    reservation.getUser().getId(),
+                    null, //todo store추가 시 추가
+                    reservation.getReservationNumber(),
+                    reservation.getNumberOfGuests(),
+                    reservation.getReservationDate(),
+                    reservation.getReservationTime(),
+                    reservation.getStatus()
+            );
+        }
+    }
+}

--- a/src/main/java/com/projectw/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/projectw/domain/reservation/entity/Reservation.java
@@ -1,0 +1,53 @@
+package com.projectw.domain.reservation.entity;
+
+import com.projectw.common.entity.Timestamped;
+import com.projectw.common.enums.ReservationStatus;
+import com.projectw.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation extends Timestamped {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 음식점 id
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private Long reservationNumber;
+
+    @Column(nullable = false)
+    private Integer numberOfGuests;
+
+    @Column(nullable = false)
+    private LocalDate reservationDate;
+
+    @Column(nullable = false)
+    private LocalTime reservationTime;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+    @Builder
+    public Reservation(/*Store store,*/ User user, Long reservationNumber, Integer numberOfGuests, LocalDate reservationDate, LocalTime reservationTime ) {
+        this.user = user;
+        this.reservationNumber = reservationNumber;
+        this.numberOfGuests = numberOfGuests;
+        this.reservationDate = reservationDate;
+        this.reservationTime = reservationTime;
+        this.status = ReservationStatus.WAITING;
+    }
+}

--- a/src/main/java/com/projectw/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/projectw/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,8 @@
+package com.projectw.domain.reservation.repository;
+
+import com.projectw.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+}

--- a/src/main/java/com/projectw/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/projectw/domain/reservation/service/ReservationService.java
@@ -1,0 +1,66 @@
+package com.projectw.domain.reservation.service;
+
+import com.projectw.common.dto.SuccessResponse;
+import com.projectw.common.enums.ResponseCode;
+import com.projectw.common.exceptions.InvalidRequestException;
+import com.projectw.domain.reservation.dto.ReserveRequest;
+import com.projectw.domain.reservation.dto.ReserveResponse;
+import com.projectw.domain.reservation.entity.Reservation;
+import com.projectw.domain.reservation.repository.ReservationRepository;
+import com.projectw.domain.user.entity.User;
+import com.projectw.security.AuthUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    public ReservationService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
+    }
+
+    /**
+     * 예약 생성
+     * @param authUser
+     * @param createRequest
+     * @return
+     */
+    public SuccessResponse<ReserveResponse.Info> reserve(AuthUser authUser, long storeId, ReserveRequest.Create createRequest) {
+        User user = User.fromAuthUser(authUser);
+
+        //todo temp
+        /*
+        Store store = storeRepository.findById(storeId).orElseThrow(()-> new InvalidRequestException(ResponseCode.NOT_FOUND_STORE))
+        */
+
+        Reservation reservation = Reservation.builder()
+                //.store(store)
+                .user(user)
+                .reservationNumber(createRequest.reservationNumber())
+                .reservationDate(createRequest.reservationDate())
+                .reservationTime(createRequest.reservationTime())
+                .numberOfGuests(createRequest.numberOfGuests())
+                .build();
+
+        reservation = reservationRepository.save(reservation);
+        return SuccessResponse.of(new ReserveResponse.Info(reservation));
+    }
+
+    /**
+     * 예약 상태 변경
+     * @param authUser 가게 사장만 가능
+     * @param storeId
+     * @param reservationId
+     * @param request
+     * @return
+     */
+    public SuccessResponse<ReserveResponse.Info> reservationStatusChange(AuthUser authUser, long storeId, long reservationId, ReserveRequest.UpdateStatus request) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new InvalidRequestException(ResponseCode.NOT_FOUND_RESERVATION));
+
+        return SuccessResponse.of(new ReserveResponse.Info(reservation));
+    }
+}

--- a/src/main/java/com/projectw/domain/review/service/ReviewService.java
+++ b/src/main/java/com/projectw/domain/review/service/ReviewService.java
@@ -1,13 +1,7 @@
 package com.projectw.domain.review.service;
 
-import com.projectw.domain.review.dto.request.ReviewRequestDto;
-import com.projectw.domain.review.dto.response.ReviewResponseDto;
 import com.projectw.domain.review.repository.ReviewRepository;
-import com.projectw.domain.user.entity.User;
-import com.projectw.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
-
-import java.awt.*;
 
 @Service
 public class ReviewService {

--- a/src/main/java/com/projectw/domain/review/service/ReviewService.java
+++ b/src/main/java/com/projectw/domain/review/service/ReviewService.java
@@ -3,7 +3,7 @@ package com.projectw.domain.review.service;
 import com.projectw.domain.review.dto.request.ReviewRequestDto;
 import com.projectw.domain.review.dto.response.ReviewResponseDto;
 import com.projectw.domain.review.repository.ReviewRepository;
-import com.projectw.domain.user.entitiy.User;
+import com.projectw.domain.user.entity.User;
 import com.projectw.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/projectw/domain/user/entity/User.java
+++ b/src/main/java/com/projectw/domain/user/entity/User.java
@@ -2,7 +2,6 @@ package com.projectw.domain.user.entity;
 
 import com.projectw.common.entity.Timestamped;
 import com.projectw.common.enums.UserRole;
-import com.projectw.domain.reservation.entity.Reservation;
 import com.projectw.security.AuthUser;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/projectw/domain/user/entity/User.java
+++ b/src/main/java/com/projectw/domain/user/entity/User.java
@@ -1,14 +1,10 @@
-package com.projectw.domain.user.entitiy;
+package com.projectw.domain.user.entity;
 
 import com.projectw.common.entity.Timestamped;
 import com.projectw.common.enums.UserRole;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.projectw.domain.reservation.entity.Reservation;
+import com.projectw.security.AuthUser;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,5 +42,14 @@ public class User extends Timestamped {
         this.nickname = nickname;
         this.role = role;
     }
-    // hihi hi
+
+    public User(Long userId, String email, UserRole role) {
+        this.id = userId;
+        this.email = email;
+        this.role = role;
+    }
+
+    public static User fromAuthUser(AuthUser authUser) {
+        return new User(authUser.getUserId(), authUser.getEmail(), authUser.getRole());
+    }
 }

--- a/src/main/java/com/projectw/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/projectw/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package com.projectw.domain.user.repository;
 
-import com.projectw.domain.user.entitiy.User;
+import com.projectw.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/projectw/security/AuthUser.java
+++ b/src/main/java/com/projectw/security/AuthUser.java
@@ -1,11 +1,12 @@
 package com.projectw.security;
 
 import com.projectw.common.enums.UserRole;
-import java.util.Collection;
-import java.util.List;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
 
 @Getter
 public class AuthUser {
@@ -13,11 +14,13 @@ public class AuthUser {
     private final Long userId;
     private final String email;
     private final Collection<? extends GrantedAuthority> authorities;
+    private final UserRole role;
 
     public AuthUser(Long userId, String email, UserRole role) {
         this.userId = userId;
         this.email = email;
         this.authorities = List.of(new SimpleGrantedAuthority(role.name()));
+        this.role = role;
     }
 
 }

--- a/src/test/java/com/projectw/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/projectw/domain/auth/service/AuthServiceTest.java
@@ -1,10 +1,5 @@
 package com.projectw.domain.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 import com.projectw.common.dto.SuccessResponse;
 import com.projectw.common.enums.UserRole;
 import com.projectw.common.exceptions.AccessDeniedException;
@@ -23,6 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {

--- a/src/test/java/com/projectw/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/projectw/domain/auth/service/AuthServiceTest.java
@@ -11,7 +11,7 @@ import com.projectw.common.exceptions.AccessDeniedException;
 import com.projectw.common.exceptions.InvalidRequestException;
 import com.projectw.domain.auth.dto.AuthRequest;
 import com.projectw.domain.auth.dto.AuthResponse.Signup;
-import com.projectw.domain.user.entitiy.User;
+import com.projectw.domain.user.entity.User;
 import com.projectw.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/projectw/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/projectw/domain/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,78 @@
+package com.projectw.domain.reservation.service;
+
+import com.projectw.common.enums.ReservationStatus;
+import com.projectw.common.enums.UserRole;
+import com.projectw.domain.reservation.dto.ReserveRequest;
+import com.projectw.domain.reservation.dto.ReserveResponse;
+import com.projectw.domain.reservation.entity.Reservation;
+import com.projectw.domain.reservation.repository.ReservationRepository;
+import com.projectw.domain.user.entity.User;
+import com.projectw.security.AuthUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Test
+    public void 예약_생성() throws Exception {
+        // given
+        AuthUser authUser = new AuthUser(1L, "email", UserRole.ROLE_USER);
+        User user = User.fromAuthUser(authUser);
+        LocalDate localDate = LocalDate.of(2024, 10, 29);
+        LocalTime localTime = LocalTime.of(15, 15, 0);
+        ReserveRequest.Create request = new ReserveRequest.Create(1L, 1L, 1, localDate, localTime);
+        Reservation reservation = new Reservation(user, request.reservationNumber(), request.numberOfGuests(), request.reservationDate(), request.reservationTime());
+        ReflectionTestUtils.setField(reservation, "id", 1L);
+        given(reservationRepository.save(any())).willReturn(reservation);
+
+        // when
+        ReserveResponse.Info data = reservationService.reserve(authUser, 1L, request).getData();
+
+        // then
+        assertThat(data.numberOfGuests()).isEqualTo(1);
+        assertThat(data.reservationDate()).isEqualTo(localDate);
+        assertThat(data.reservationTime()).isEqualTo(localTime);
+        assertThat(data.userId()).isEqualTo(1L);
+        assertThat(data.reserveId()).isEqualTo(1L);
+        assertThat(data.status()).isEqualTo(ReservationStatus.WAITING);
+    }
+
+    @Test
+    public void 예약_생성_스토어를_찾을_수_없다면_예외발생() throws Exception {
+        // given
+//        AuthUser authUser = new AuthUser(1L, "email", UserRole.ROLE_USER);
+//        User user = User.fromAuthUser(authUser);
+//        LocalDate localDate = LocalDate.of(2024, 10, 29);
+//        LocalTime localTime = LocalTime.of(15, 15, 0);
+//        ReserveRequest.Create request = new ReserveRequest.Create(1L, 1L, 1, localDate, localTime);
+//        Reservation reservation = new Reservation(user, request.reservationNumber(), request.numberOfGuests(), request.reservationDate(), request.reservationTime());
+//        ReflectionTestUtils.setField(reservation, "id", 1L);
+
+        // given(storeRepository.findById(any())).willReturn(Optional.empty());
+
+//        given(reservationRepository.save(any())).willReturn(reservation);
+
+        // when then
+//        assertThatThrownBy(()-> reservationService.reserve(authUser, 1L, request))
+//                .isInstanceOf(InvalidRequestException.class)
+//                .hasMessage("");
+    }
+}


### PR DESCRIPTION
## 📝작업 내용
* 유저 권한에 OWNER 추가
* 예약 상태 enum 추가
* jacoco 제외 클래스 추가(entity)
* domain.user -> 엔티티 오타 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
